### PR TITLE
fixing broken link

### DIFF
--- a/examples/AzureML-REST-API/README.md
+++ b/examples/AzureML-REST-API/README.md
@@ -13,4 +13,4 @@ description: "Examples of using the Azure Machine Learning REST API."
 
 Learn how to use the REST API to accomplish the following tasks with Azure Machine Learning:
 
-* [Submit a training run](https://github.com/microsoft/mlops/tree/master/examples/azureml-rest-api/rest-submit-run.md)
+* [Submit a training run](https://github.com/microsoft/MLOps/blob/master/examples/AzureML-REST-API/rest-submit-run.md)


### PR DESCRIPTION
Fixing a 404 error. Capitalization matters in this case.