### PR TITLE
Add FileDataset mounting input option to training pipelines example

### DIFF
--- a/examples/AzureML-Primers/06 - Automating ML Workflows with Pipelines.ipynb
+++ b/examples/AzureML-Primers/06 - Automating ML Workflows with Pipelines.ipynb
@@ -215,7 +215,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use mounted FileDataset in one of our [later pipeline examples](http://localhost:8888/notebooks/06%20-%20Automating%20ML%20Workflows%20with%20Pipelines.ipynb#Task-3:-Create-and-Run-a-Pipeline)."
+    "We use this mounted FileDataset in one of our [later pipeline examples](http://localhost:8888/notebooks/06%20-%20Automating%20ML%20Workflows%20with%20Pipelines.ipynb#Task-3:-Create-and-Run-a-Pipeline)."
    ]
   },
   {

--- a/examples/AzureML-Primers/06 - Automating ML Workflows with Pipelines.ipynb
+++ b/examples/AzureML-Primers/06 - Automating ML Workflows with Pipelines.ipynb
@@ -1,170 +1,602 @@
 {
-  "cells": [
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "# Exercise 5 - Automating ML Workflows with Pipelines\n\nIn the previous exercises, you explored the entire machine learning process from accessing data through to training and deploying machine learning models. Up until now, you have performed the various steps required to create a machine learning solution interactively. In this exercise, you'll explore automation of these steps using *pipelines*.\n\n> **Important**: This exercise assumes you have completed the previous exercises in this series - specifically, you must have:\n>\n> - Created an Azure ML Workspace.\n> - Uploaded the diabetes.csv data file to the workspace's default datastore.\n> - Created a dataset called **Diabetes Dataset**.\n> - Created an Azure ML compute resource named **cpu-compute**\n>\n> If you haven't done that, there's no time like the present!\n\n> **More Information**: For more information about Azure ML Pipelines, see the [documentation](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-ml-pipelines).\n\n## Task 1: Connect to Your Workspace\n\nThe first thing you need to do is to connect to your workspace using the Azure ML SDK. Let's start by ensuring you still have the latest version installed (if you ended and restarted your Azure Notebooks session, the environment may have been reset)"
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "!pip install --upgrade azureml-sdk[notebooks]\n\nimport azureml.core\nprint(\"Ready to use Azure ML\", azureml.core.VERSION)",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "Now you're ready to connect to your workspace. When you created it in the previous exercise, you saved its configuration; so now you can simply load the workspace from its configuration file.\n\n> **Note**: If the authenticated session with your Azure subscription has expired since you completed the previous exercise, you'll be prompted to reauthenticate."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "from azureml.core import Workspace\n\n# Load the workspace from the saved config file\nws = Workspace.from_config()\nprint('Ready to work with', ws.name)",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "## Task 2: Prepare the Pipeline Environment\n\nPipelines consist of one or more *steps*, which can be Python scripts, or specialized steps like an Auto ML training estimator or a data transfer step that copies data from one location to another. Each step can run in its own compute context.\n\nIn this exercise, you'll build a simple pipeline that contains two Python script steps (one to train a model, and another to register the trained model). Before creating the pipeline however, you'll need to prepare the environment by creating the scripts for each step, and defining compute and run configuration for the steps. \n\nLet's start by creating a folder for our pipeline step scripts."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "import os\n# Create a folder for the experiment files\nexperiment_name = 'diabetes_pipeline'\nexperiment_folder = './' + experiment_name\nos.makedirs(experiment_folder, exist_ok=True)\n\nprint(experiment_folder)",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "Now you can create the script for the first step, which will train a model. The script includes the following parameters:\n\n- **dataset_name**: The name of the dataset in your workspace to be used as source data for training.\n- **regularization**: The regularization rate to be used when training a logistic regression model.\n- **output_folder** the folder where the trained model should be saved."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "%%writefile $experiment_folder/train_diabetes.py\n# Import libraries\nimport argparse\nimport joblib\nfrom azureml.core import Workspace, Dataset, Experiment, Run\nimport pandas as pd\nimport numpy as np\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.linear_model import LogisticRegression\n\n\n# Get parameters\nparser = argparse.ArgumentParser()\nparser.add_argument('--dataset_name', type=str, dest='dataset_name', default=\"Diabetes Dataset\", help='source dataset')\nparser.add_argument('--regularization', type=float, dest='reg_rate', default=0.01, help='regularization rate')\nparser.add_argument('--output_folder', type=str, dest='output_folder', default=\"diabetes_model\", help='output folder')\nargs = parser.parse_args()\nreg = args.reg_rate\ndataset_name = args.dataset_name\noutput_folder = args.output_folder\n\n# Get the experiment run context\nrun = Run.get_context()\n\n# load the diabetes dataset\nprint(\"Loading data from \" + dataset_name)\ndiabetes = Dataset.get_by_name(workspace=run.experiment.workspace, name=dataset_name).to_pandas_dataframe()\n\n# Separate features and labels\nX, y = diabetes[['Pregnancies','PlasmaGlucose','DiastolicBloodPressure','TricepsThickness','SerumInsulin','BMI','DiabetesPedigree','Age']].values, diabetes['Diabetic'].values\n\n# Train a logistic regression model\nprint('Training a logistic regression model with regularization rate of', reg)\nrun.log('Regularization Rate',  np.float(reg))\nmodel = LogisticRegression(C=1/reg, solver=\"liblinear\").fit(X, y)\n\n# Save the trained model\nos.makedirs(output_folder, exist_ok=True)\noutput_path = output_folder + \"/model.pkl\"\njoblib.dump(value=model, filename=output_path)\n\nrun.complete()",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "The script for the second step of the pipeline will load the model from where it was saved, and then register it in the workspace. It includes a single **model_path** parameter that contains the path where the model was saved."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "%%writefile $experiment_folder/register_diabetes.py\n# Import libraries\nimport argparse\nimport joblib\nfrom azureml.core import Workspace, Model, Run\n\n# Get parameters\nparser = argparse.ArgumentParser()\nparser.add_argument('--model_folder', type=str, dest='model_folder', default=\"diabetes_model\", help='model location')\nargs = parser.parse_args()\nmodel_folder = args.model_folder\n\n# Get the experiment run context\nrun = Run.get_context()\n\n# load the model\nprint(\"Loading model from \" + model_folder)\nmodel_file = model_folder + \"/model.pkl\"\nmodel = joblib.load(model_file)\n\nModel.register(workspace=run.experiment.workspace,\n               model_path = model_file,\n               model_name = 'diabetes_model',\n               tags={'Training context':'Pipeline'})\n\nrun.complete()",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "In this exercise, you'll use the same compute for both steps, but it's important to realize that each step is run independently; so you could specify different compute contexts for each step if appropriate."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "from azureml.core.compute import ComputeTarget, AmlCompute\nfrom azureml.core.compute_target import ComputeTargetException\n\n# Choose a name for your CPU cluster\ncpu_cluster_name = \"cpu-cluster\"\n\n# Verify that cluster does not exist already\ntry:\n    cpu_cluster = ComputeTarget(workspace=ws, name=cpu_cluster_name)\n    print('Found existing cluster, use it.')\nexcept ComputeTargetException:\n    # Create an AzureMl Compute resource (a container cluster)\n    compute_config = AmlCompute.provisioning_configuration(vm_size='STANDARD_D2_V2', \n                                                           vm_priority='lowpriority', \n                                                           max_nodes=4)\n    cpu_cluster = ComputeTarget.create(ws, cpu_cluster_name, compute_config)\n\ncpu_cluster.wait_for_completion(show_output=True)",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "The compute will require a Python environment with the necessary package dependencies installed, so we'll create a run configuration."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "from azureml.core.runconfig import RunConfiguration\nfrom azureml.core.conda_dependencies import CondaDependencies\n\n# Create a new runconfig object\npipeline_run_config = RunConfiguration()\n\n# Use the compute you created above. \npipeline_run_config.target = cpu_cluster\n\n# Enable Docker\npipeline_run_config.environment.docker.enabled = True\n\n# Specify CondaDependencies obj, add necessary packages\npipeline_run_config.environment.python.user_managed_dependencies = False\npipeline_run_config.environment.python.conda_dependencies = CondaDependencies.create(\n    conda_packages=['pandas','scikit-learn'], \n    pip_packages=['azureml-sdk', 'pyarrow'])\n\nprint (\"Run configuration created.\")",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "## Task 3: Create and Run a Pipeline\n\nNow we're ready to create and run a pipeline.\n\nFirst we need to define the steps for the pipeline, and any data references that need to passed between them. In this case, the first step must write the model to a folder that can be read from by the second step. Since the steps will be run on remote compute (and in fact, could each be run on different compute), the folder path must be passed as a data reference to a location in a datastore within the workspace. The **PipelineData** object is just that, so we'll create one and use at as the output for the first step and the input for the second step. Note that we also need to pass it as a script argument so our code can access the datastore location referenced by the data reference."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "from azureml.pipeline.core import PipelineData\nfrom azureml.pipeline.steps import PythonScriptStep\n\n# Create a PipelineData (Data Reference) for the model folder\nmodel_folder = PipelineData(\"model_folder\", datastore=ws.get_default_datastore())\n\n# Step 1, run the training script\ntrain_step = PythonScriptStep(name = \"Train Model\",\n                                source_directory = experiment_folder,\n                                script_name = \"train_diabetes.py\",\n                                arguments = ['--dataset_name', 'Diabetes Dataset',\n                                             '--regularization', 0.1,\n                                             '--output_folder', model_folder],\n                                outputs=[model_folder],\n                                compute_target = cpu_cluster,\n                                runconfig = pipeline_run_config,\n                                allow_reuse = False)\n\n# Step 2, run the model registration script\nregister_step = PythonScriptStep(name = \"Register Model\",\n                                source_directory = experiment_folder,\n                                script_name = \"register_diabetes.py\",\n                                arguments = ['--model_folder', model_folder],\n                                inputs=[model_folder],\n                                compute_target = cpu_cluster,\n                                runconfig = pipeline_run_config,\n                                allow_reuse = False)\n\nprint(\"Pipeline steps defined\")",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "OK, we're ready to go. let's build the pipeline from the steps we've defined and run it in an experiment."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "from azureml.core import Experiment\nfrom azureml.pipeline.core import Pipeline\nfrom azureml.widgets import RunDetails\n\n# Construct the pipeline\npipeline_steps = [train_step, register_step]\npipeline = Pipeline(workspace = ws, steps=pipeline_steps)\nprint(\"Pipeline is built.\")\n\n# Create an experiment and run the pipeline\nexperiment = Experiment(workspace = ws, name = experiment_name)\npipeline_run = experiment.submit(pipeline, regenerate_outputs=True)\nprint(\"Pipeline submitted for execution.\")\n\nRunDetails(pipeline_run).show()",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "When the pipeline has finished, a new model should be registered with a *Training context* tag indicating it was trained in a pipeline. Run the following code to verify this."
-    },
-    {
-      "metadata": {
-        "trusted": true
-      },
-      "cell_type": "code",
-      "source": "from azureml.core import Model\n\nfor model in Model.list(ws):\n    print(model.name, 'version:', model.version)\n    for tag_name in model.tags:\n        tag = model.tags[tag_name]\n        print ('\\t',tag_name, ':', tag)\n    for prop_name in model.properties:\n        prop = model.properties[prop_name]\n        print ('\\t',prop_name, ':', prop)\n    print('\\n')",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "metadata": {},
-      "cell_type": "markdown",
-      "source": "This is a simple example, designed to demonstrate the principle. In reality, you could build more sophisticated logic into the pipeline steps - for example, evaluating the model against some test data to calculate a performance metric like AUC or accuracy, comparing the metric to that of any previously registered versions of the model, and only registering the new model if it performs better.\n\nYou can use the [Azure Machine Learning extension for Azure DevOps](https://marketplace.visualstudio.com/items?itemName=ms-air-aiagility.vss-services-azureml) to combine Azure ML pipelines with Azure DevOps pipelines (yes, it *is* confusing that they have the same name!) and integrate model retraining into a *continuous integration/continuous deployment (CI/CD)* process. For example you could use an Azure DevOps *build* pipeline to trigger an Azure ML pipeline that trains and registers a model, and when the model is registered it could trigger an Azure Devops *release* pipeline that deploys the model as a web service, along with the application or service that consumes the model."
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "name": "python36",
-      "display_name": "Python 3.6",
-      "language": "python"
-    },
-    "language_info": {
-      "mimetype": "text/x-python",
-      "nbconvert_exporter": "python",
-      "name": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.6.6",
-      "file_extension": ".py",
-      "codemirror_mode": {
-        "version": 3,
-        "name": "ipython"
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exercise 6 - Automating ML Workflows with Pipelines\n",
+    "\n",
+    "In the previous exercises, you explored the entire machine learning process from accessing data through to training and deploying machine learning models. Up until now, you have performed the various steps required to create a machine learning solution interactively. In this exercise, you'll explore automation of these steps using *pipelines*.\n",
+    "\n",
+    "> **Important**: This exercise assumes you have completed the previous exercises in this series - specifically, you must have:\n",
+    ">\n",
+    "> - Created an Azure ML Workspace.\n",
+    "> - Uploaded the diabetes.csv data file to the workspace's default datastore.\n",
+    "> - Created a dataset called **Diabetes Dataset**.\n",
+    "> - Created an Azure ML compute resource named **cpu-compute**\n",
+    ">\n",
+    "> If you haven't done that, there's no time like the present!\n",
+    "\n",
+    "> **More Information**: For more information about Azure ML Pipelines, see the [documentation](https://docs.microsoft.com/en-us/azure/machine-learning/service/concept-ml-pipelines).\n",
+    "\n",
+    "## Task 1: Connect to Your Workspace\n",
+    "\n",
+    "The first thing you need to do is to connect to your workspace using the Azure ML SDK. Let's start by ensuring you still have the latest version installed (if you ended and restarted your Azure Notebooks session, the environment may have been reset)"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade azureml-sdk[notebooks]\n",
+    "\n",
+    "import azureml.core\n",
+    "print(\"Ready to use Azure ML\", azureml.core.VERSION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now you're ready to connect to your workspace. When you created it in the previous exercise, you saved its configuration; so now you can simply load the workspace from its configuration file.\n",
+    "\n",
+    "> **Note**: If the authenticated session with your Azure subscription has expired since you completed the previous exercise, you'll be prompted to reauthenticate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.core import Workspace\n",
+    "\n",
+    "# Load the workspace from the saved config file\n",
+    "ws = Workspace.from_config()\n",
+    "print('Ready to work with', ws.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 2: Prepare the Pipeline Environment\n",
+    "\n",
+    "Pipelines consist of one or more *steps*, which can be Python scripts, or specialized steps like an Auto ML training estimator or a data transfer step that copies data from one location to another. Each step can run in its own compute context.\n",
+    "\n",
+    "In this exercise, you'll build a simple pipeline that contains two Python script steps (one to train a model, and another to register the trained model). Before creating the pipeline however, you'll need to prepare the environment by creating the scripts for each step, and defining compute and run configuration for the steps. \n",
+    "\n",
+    "Let's start by creating a folder for our pipeline step scripts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "# Create a folder for the experiment files\n",
+    "experiment_name = 'diabetes_pipeline'\n",
+    "experiment_folder = './' + experiment_name\n",
+    "os.makedirs(experiment_folder, exist_ok=True)\n",
+    "\n",
+    "print(experiment_folder)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Python script creation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When defining scripts to run in our pipelines, we can choose between two primary ways to ingest Azure Machine Learning [Datasets](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.core.dataset.dataset?view=azure-ml-py). \n",
+    "\n",
+    "- One is from the run context of our script when it is executed on the compute target.\n",
+    "\n",
+    "- Alternatively, the use of a [FileDataset](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.data.filedataset?view=azure-ml-py) can allow us to mount and pass in the path to files represented by a Dataset at runtime.\n",
+    "\n",
+    "The former pattern is great for keeping everything in the cloud, and when as a development team we are making changes simultaneously to our source code and AML pipelines, meaning that our scripts need only ever run on our compute targets - on which the run context will always have an assigned Workspace.\n",
+    "\n",
+    "The latter pattern smoothes the transition from local development of scripts, to their consumption in pipelines, by allowing us to utilise environment variables leading to our dataset files in either context. We can thus remove any reference to run context from our scripts, and run them locally, in order to iterate quickly, while safely expecting the same remote behaviour when the pipeline is submitted for execution.\n",
+    "\n",
+    "The difference can be seen in the script definitions below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 1 - Retrieving datasets from the Workspace via the Run context\n",
+    "\n",
+    "This will create the source code file `train_diabetes_no_pipeline_input.py`.\n",
+    "\n",
+    "The script includes the following parameters:\n",
+    "\n",
+    "- **dataset_name**: The name of the dataset in your workspace to be used as source data for training.\n",
+    "- **regularization**: The regularization rate to be used when training a logistic regression model.\n",
+    "- **output_folder** the folder where the trained model should be saved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile $experiment_folder/train_diabetes_no_pipeline_input.py\n",
+    "# Import libraries\n",
+    "import argparse\n",
+    "import joblib\n",
+    "from azureml.core import Workspace, Dataset, Experiment, Run\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "\n",
+    "# Get parameters\n",
+    "parser = argparse.ArgumentParser()\n",
+    "parser.add_argument('--dataset_name', type=str, dest='dataset_name', default=\"Diabetes Dataset\", help='source dataset')\n",
+    "parser.add_argument('--regularization', type=float, dest='reg_rate', default=0.01, help='regularization rate')\n",
+    "parser.add_argument('--output_folder', type=str, dest='output_folder', default=\"diabetes_model\", help='output folder')\n",
+    "args = parser.parse_args()\n",
+    "reg = args.reg_rate\n",
+    "dataset_name = args.dataset_name\n",
+    "output_folder = args.output_folder\n",
+    "\n",
+    "# Get the experiment run context\n",
+    "run = Run.get_context()\n",
+    "\n",
+    "# load the diabetes dataset\n",
+    "print(\"Loading data from \" + dataset_name)\n",
+    "diabetes = Dataset.get_by_name(workspace=run.experiment.workspace, name=dataset_name).to_pandas_dataframe()\n",
+    "\n",
+    "# Separate features and labels\n",
+    "X, y = diabetes[['Pregnancies','PlasmaGlucose','DiastolicBloodPressure','TricepsThickness','SerumInsulin','BMI','DiabetesPedigree','Age']].values, diabetes['Diabetic'].values\n",
+    "\n",
+    "# Train a logistic regression model\n",
+    "print('Training a logistic regression model with regularization rate of', reg)\n",
+    "run.log('Regularization Rate',  np.float(reg))\n",
+    "model = LogisticRegression(C=1/reg, solver=\"liblinear\").fit(X, y)\n",
+    "\n",
+    "# Save the trained model\n",
+    "os.makedirs(output_folder, exist_ok=True)\n",
+    "output_path = output_folder + \"/model.pkl\"\n",
+    "joblib.dump(value=model, filename=output_path)\n",
+    "\n",
+    "run.complete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 2 - Reading datasets from mounted input files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we require a FileDataset in order to take advantage of the mounting functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.core import Dataset\n",
+    "\n",
+    "# Retrieve diabetes dataset as a FileDataset\n",
+    "diabetes_file_dataset = Dataset.File.from_files(\n",
+    "        path=[(ws.get_default_datastore(), \"diabetes-data/diabetes.csv\")], validate=True\n",
+    ")\n",
+    "\n",
+    "print(\"Sourced Dataset:\\n{}\".format(diabetes_file_dataset))\n",
+    "\n",
+    "# And ready for direct input to a pipeline step...\n",
+    "\n",
+    "# This creates a context manager which automatically mounts the file to the\n",
+    "# compute environment at runtime.\n",
+    "diabetes_file_dataset = diabetes_file_dataset.as_named_input('training_dataset').as_mount()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use mounted FileDataset in one of our [later pipeline examples](http://localhost:8888/notebooks/06%20-%20Automating%20ML%20Workflows%20with%20Pipelines.ipynb#Task-3:-Create-and-Run-a-Pipeline)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we create `train_diabetes_with_pipeline_input.py`: a script which retrieves the mounted input without relying on knowledge or existence of a run context. This can be run and iterated on locally like any other Python script.\n",
+    "\n",
+    "The script includes the following parameters:\n",
+    "\n",
+    "- **regularization**: The regularization rate to be used when training a logistic regression model.\n",
+    "- **output_folder** the folder where the trained model should be saved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile $experiment_folder/train_diabetes_with_pipeline_input.py\n",
+    "# Import libraries\n",
+    "import os\n",
+    "import argparse\n",
+    "import joblib\n",
+    "from azureml.core import Run\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "\n",
+    "\n",
+    "# Get parameters\n",
+    "parser = argparse.ArgumentParser()\n",
+    "\n",
+    "# Notice no dataset name is required in this version\n",
+    "parser.add_argument('--regularization', type=float, dest='reg_rate', default=0.01, help='regularization rate')\n",
+    "parser.add_argument('--output_folder', type=str, dest='output_folder', default=\"diabetes_model\", help='output folder')\n",
+    "args = parser.parse_args()\n",
+    "reg = args.reg_rate\n",
+    "output_folder = args.output_folder\n",
+    "\n",
+    "dataset_path = os.environ['training_dataset'] # The key here is the name of the input created from the Dataset\n",
+    "\n",
+    "# Get the experiment run context\n",
+    "# We longer need this for I/O, but can continue to use it for logging etc., even locally.\n",
+    "run = Run.get_context()\n",
+    "\n",
+    "# load the diabetes dataset\n",
+    "print(\"Loading data from \" + dataset_path)\n",
+    "# Simply use pandas as with a local file\n",
+    "diabetes = pd.read_csv(dataset_path)\n",
+    "\n",
+    "print(\"Data retrieved: {}\\n\".format(diabetes))\n",
+    "\n",
+    "# Separate features and labels\n",
+    "X, y = diabetes[['Pregnancies','PlasmaGlucose','DiastolicBloodPressure','TricepsThickness','SerumInsulin','BMI','DiabetesPedigree','Age']].values, diabetes['Diabetic'].values\n",
+    "\n",
+    "# Train a logistic regression model\n",
+    "print('Training a logistic regression model with regularization rate of', reg)\n",
+    "run.log('Regularization Rate',  np.float(reg))\n",
+    "model = LogisticRegression(C=1/reg, solver=\"liblinear\").fit(X, y)\n",
+    "\n",
+    "# Save the trained model\n",
+    "os.makedirs(output_folder, exist_ok=True)\n",
+    "output_path = output_folder + \"/model.pkl\"\n",
+    "joblib.dump(value=model, filename=output_path)\n",
+    "\n",
+    "run.complete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model registration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The script for the second step of the pipeline will load the model from where it was saved, and then register it in the workspace. It includes a single **model_path** parameter that contains the path where the model was saved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile $experiment_folder/register_diabetes.py\n",
+    "# Import libraries\n",
+    "import argparse\n",
+    "import joblib\n",
+    "from azureml.core import Workspace, Model, Run\n",
+    "\n",
+    "# Get parameters\n",
+    "parser = argparse.ArgumentParser()\n",
+    "parser.add_argument('--model_folder', type=str, dest='model_folder', default=\"diabetes_model\", help='model location')\n",
+    "args = parser.parse_args()\n",
+    "model_folder = args.model_folder\n",
+    "\n",
+    "# Get the experiment run context\n",
+    "run = Run.get_context()\n",
+    "\n",
+    "# load the model\n",
+    "print(\"Loading model from \" + model_folder)\n",
+    "model_file = model_folder + \"/model.pkl\"\n",
+    "model = joblib.load(model_file)\n",
+    "\n",
+    "Model.register(workspace=run.experiment.workspace,\n",
+    "               model_path = model_file,\n",
+    "               model_name = 'diabetes_model',\n",
+    "               tags={'Training context':'Pipeline'})\n",
+    "\n",
+    "run.complete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this exercise, you'll use the same compute for both steps, but it's important to realize that each step is run independently; so you could specify different compute contexts for each step if appropriate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.core.compute import ComputeTarget, AmlCompute\n",
+    "from azureml.core.compute_target import ComputeTargetException\n",
+    "\n",
+    "# Choose a name for your CPU cluster\n",
+    "cpu_cluster_name = \"cpu-cluster\"\n",
+    "\n",
+    "# Verify that cluster does not exist already\n",
+    "try:\n",
+    "    cpu_cluster = ComputeTarget(workspace=ws, name=cpu_cluster_name)\n",
+    "    print('Found existing cluster, use it.')\n",
+    "except ComputeTargetException:\n",
+    "    # Create an AzureMl Compute resource (a container cluster)\n",
+    "    compute_config = AmlCompute.provisioning_configuration(vm_size='STANDARD_D2_V2', \n",
+    "                                                           vm_priority='lowpriority', \n",
+    "                                                           max_nodes=4)\n",
+    "    cpu_cluster = ComputeTarget.create(ws, cpu_cluster_name, compute_config)\n",
+    "\n",
+    "cpu_cluster.wait_for_completion(show_output=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The compute will require a Python environment with the necessary package dependencies installed, so we'll create a run configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.core.runconfig import RunConfiguration\n",
+    "from azureml.core.conda_dependencies import CondaDependencies\n",
+    "\n",
+    "# Create a new runconfig object\n",
+    "pipeline_run_config = RunConfiguration()\n",
+    "\n",
+    "# Use the compute you created above. \n",
+    "pipeline_run_config.target = cpu_cluster\n",
+    "\n",
+    "# Enable Docker\n",
+    "pipeline_run_config.environment.docker.enabled = True\n",
+    "\n",
+    "# Specify CondaDependencies obj, add necessary packages\n",
+    "pipeline_run_config.environment.python.user_managed_dependencies = False\n",
+    "pipeline_run_config.environment.python.conda_dependencies = CondaDependencies.create(\n",
+    "    conda_packages=['pandas','scikit-learn'], \n",
+    "    pip_packages=['azureml-sdk', 'pyarrow'])\n",
+    "\n",
+    "print (\"Run configuration created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 3: Create and Run a Pipeline\n",
+    "\n",
+    "Now we're ready to create and run a pipeline.\n",
+    "\n",
+    "First we need to define the steps for the pipeline, and any data references that need to passed between them. In this case, the first step must write the model to a folder that can be read from by the second step. Since the steps will be run on remote compute (and in fact, could each be run on different compute), the folder path must be passed as a data reference to a location in a datastore within the workspace. The **PipelineData** object is just that, so we'll create one and use at as the output for the first step and the input for the second step. Note that we also need to pass it as a script argument so our code can access the datastore location referenced by the data reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pipeline for option 1 - Retrieving input dataset from run context"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.pipeline.core import PipelineData\n",
+    "from azureml.pipeline.steps import PythonScriptStep\n",
+    "\n",
+    "# Create a PipelineData (Data Reference) for the model folder\n",
+    "model_folder = PipelineData(\"model_folder\", datastore=ws.get_default_datastore())\n",
+    "\n",
+    "# Step 1, run the training script\n",
+    "train_step = PythonScriptStep(name = \"Train Model\",\n",
+    "                                source_directory = experiment_folder,\n",
+    "                                script_name = \"train_diabetes_no_pipeline_input.py\",\n",
+    "                                arguments = ['--dataset_name', 'Diabetes Dataset',\n",
+    "                                             '--regularization', 0.1,\n",
+    "                                             '--output_folder', model_folder],\n",
+    "                                outputs=[model_folder],\n",
+    "                                compute_target = cpu_cluster,\n",
+    "                                runconfig = pipeline_run_config,\n",
+    "                                allow_reuse = False)\n",
+    "\n",
+    "# Step 2, run the model registration script\n",
+    "register_step = PythonScriptStep(name = \"Register Model\",\n",
+    "                                source_directory = experiment_folder,\n",
+    "                                script_name = \"register_diabetes.py\",\n",
+    "                                arguments = ['--model_folder', model_folder],\n",
+    "                                inputs=[model_folder],\n",
+    "                                compute_target = cpu_cluster,\n",
+    "                                runconfig = pipeline_run_config,\n",
+    "                                allow_reuse = False)\n",
+    "\n",
+    "print(\"Pipeline steps defined\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pipeline for option 2 - Retrieving input dataset from mount"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice here the use of the `inputs` parameter to PythonScriptStep. This is where we pass in our mounted FileDataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.pipeline.core import PipelineData\n",
+    "from azureml.pipeline.steps import PythonScriptStep\n",
+    "\n",
+    "# Create a PipelineData (Data Reference) for the model folder\n",
+    "model_folder = PipelineData(\"model_folder\", datastore=ws.get_default_datastore())\n",
+    "\n",
+    "# Step 1, run the training script\n",
+    "\n",
+    "# Here we define a list of inputs and provide our FileDataset as an mounted input named 'training_dataset'\n",
+    "# This name forms the key of the environment variable to which the path to the file is the value\n",
+    "# at runtime.\n",
+    "train_step = PythonScriptStep(name = \"Train Model\",\n",
+    "                                source_directory = experiment_folder,\n",
+    "                                script_name = \"train_diabetes_with_pipeline_input.py\",\n",
+    "                                arguments = ['--regularization', 0.1,\n",
+    "                                             '--output_folder', model_folder],\n",
+    "                                inputs=[diabetes_file_dataset],\n",
+    "                                outputs=[model_folder],\n",
+    "                                compute_target = cpu_cluster,\n",
+    "                                runconfig = pipeline_run_config,\n",
+    "                                allow_reuse = False)\n",
+    "\n",
+    "# Step 2, run the model registration script\n",
+    "register_step = PythonScriptStep(name = \"Register Model\",\n",
+    "                                source_directory = experiment_folder,\n",
+    "                                script_name = \"register_diabetes.py\",\n",
+    "                                arguments = ['--model_folder', model_folder],\n",
+    "                                inputs=[model_folder],\n",
+    "                                compute_target = cpu_cluster,\n",
+    "                                runconfig = pipeline_run_config,\n",
+    "                                allow_reuse = False)\n",
+    "\n",
+    "print(\"Pipeline steps defined\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "OK, we're ready to go. let's build the pipeline from the steps we've defined and run it in an experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.core import Experiment\n",
+    "from azureml.pipeline.core import Pipeline\n",
+    "from azureml.widgets import RunDetails\n",
+    "\n",
+    "# Construct the pipeline\n",
+    "pipeline_steps = [train_step, register_step]\n",
+    "pipeline = Pipeline(workspace = ws, steps=pipeline_steps)\n",
+    "print(\"Pipeline is built.\")\n",
+    "\n",
+    "# Create an experiment and run the pipeline\n",
+    "experiment = Experiment(workspace = ws, name = experiment_name)\n",
+    "pipeline_run = experiment.submit(pipeline, regenerate_outputs=True)\n",
+    "print(\"Pipeline submitted for execution.\")\n",
+    "\n",
+    "RunDetails(pipeline_run).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the pipeline has finished, a new model should be registered with a *Training context* tag indicating it was trained in a pipeline. Run the following code to verify this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azureml.core import Model\n",
+    "\n",
+    "for model in Model.list(ws):\n",
+    "    print(model.name, 'version:', model.version)\n",
+    "    for tag_name in model.tags:\n",
+    "        tag = model.tags[tag_name]\n",
+    "        print ('\\t',tag_name, ':', tag)\n",
+    "    for prop_name in model.properties:\n",
+    "        prop = model.properties[prop_name]\n",
+    "        print ('\\t',prop_name, ':', prop)\n",
+    "    print('\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a simple example, designed to demonstrate the principle. In reality, you could build more sophisticated logic into the pipeline steps - for example, evaluating the model against some test data to calculate a performance metric like AUC or accuracy, comparing the metric to that of any previously registered versions of the model, and only registering the new model if it performs better.\n",
+    "\n",
+    "You can use the [Azure Machine Learning extension for Azure DevOps](https://marketplace.visualstudio.com/items?itemName=ms-air-aiagility.vss-services-azureml) to combine Azure ML pipelines with Azure DevOps pipelines (yes, it *is* confusing that they have the same name!) and integrate model retraining into a *continuous integration/continuous deployment (CI/CD)* process. For example you could use an Azure DevOps *build* pipeline to trigger an Azure ML pipeline that trains and registers a model, and when the model is registered it could trigger an Azure Devops *release* pipeline that deploys the model as a web service, along with the application or service that consumes the model."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/examples/AzureML-Primers/06 - Automating ML Workflows with Pipelines.ipynb
+++ b/examples/AzureML-Primers/06 - Automating ML Workflows with Pipelines.ipynb
@@ -215,7 +215,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use this mounted FileDataset in one of our [later pipeline examples](http://localhost:8888/notebooks/06%20-%20Automating%20ML%20Workflows%20with%20Pipelines.ipynb#Task-3:-Create-and-Run-a-Pipeline)."
+    "We use this mounted FileDataset in one of our [later pipeline examples](#Task-3:-Create-and-Run-a-Pipeline)."
    ]
   },
   {


### PR DESCRIPTION
Hi!

Noticed this neat pattern while working on AML pipelines for a customer. Use of FileDataset allows mounting of dataset files as input to a pipeline, and retrieval of the path to these files via environment variables in our Python scripts. 

For us this was a much more intuitive approach, and more transferable between local dev and consumption of scripts via pipelines, especially for our data scientists.

This PR adds it to the 6th primer as an alternative option.